### PR TITLE
Running same tests under .NET4

### DIFF
--- a/AssertExLib.sln
+++ b/AssertExLib.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssertExLib", "Source\AssertExLib.csproj", "{8CB2D8F2-4C6A-4C13-87DA-D3C85A4A12D1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3E25BF03-5503-4D73-88BB-91848E5955C1}"
@@ -15,16 +15,28 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{044422
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{52049896-1091-422D-A457-66229308A4BC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests.NET4", "UnitTests.NET4\UnitTests.NET4.csproj", "{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{52049896-1091-422D-A457-66229308A4BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52049896-1091-422D-A457-66229308A4BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52049896-1091-422D-A457-66229308A4BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52049896-1091-422D-A457-66229308A4BC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CB2D8F2-4C6A-4C13-87DA-D3C85A4A12D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CB2D8F2-4C6A-4C13-87DA-D3C85A4A12D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8CB2D8F2-4C6A-4C13-87DA-D3C85A4A12D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CB2D8F2-4C6A-4C13-87DA-D3C85A4A12D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/AssertExLib.csproj
+++ b/Source/AssertExLib.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>AssertExLib</RootNamespace>
     <AssemblyName>AssertExLib</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile47</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile37</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>

--- a/UnitTests.NET4/Properties/AssemblyInfo.cs
+++ b/UnitTests.NET4/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UnitTests.NET4")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UnitTests.NET4")]
+[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b29f03f5-8712-4b7f-9f02-7daef76a44bb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests.NET4/UnitTests.NET4.csproj
+++ b/UnitTests.NET4/UnitTests.NET4.csproj
@@ -4,12 +4,12 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{52049896-1091-422D-A457-66229308A4BC}</ProjectGuid>
+    <ProjectGuid>{BC2415FE-DEAA-4891-BACC-B4BC5518F04C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UnitTests</RootNamespace>
-    <AssemblyName>UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>UnitTests.NET4</RootNamespace>
+    <AssemblyName>UnitTests.NET4</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET4</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -27,11 +27,14 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET4</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
+      <HintPath>..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.0\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -39,15 +42,18 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit, Version=1.9.1.1600, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="xunit">
       <HintPath>..\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssertExTests.cs" />
+    <Compile Include="..\UnitTests\AssertExTests.cs">
+      <Link>AssertExTests.cs</Link>
+    </Compile>
+    <Compile Include="..\UnitTests\RecorderTests.cs">
+      <Link>RecorderTests.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RecorderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Source\AssertExLib.csproj">

--- a/UnitTests.NET4/packages.config
+++ b/UnitTests.NET4/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CompilerServices.AsyncTargetingPack" version="1.0.0" targetFramework="net40" />
+  <package id="xunit" version="1.9.1" targetFramework="net40" />
+</packages>

--- a/UnitTests/AssertExTests.cs
+++ b/UnitTests/AssertExTests.cs
@@ -3,6 +3,11 @@ using AssertExLib;
 using AssertExLib.Exceptions;
 using System;
 using Xunit;
+#if NET4
+using TaskEx = System.Threading.Tasks.TaskEx;
+#else
+using TaskEx = System.Threading.Tasks.Task;
+#endif
 
 public class AssertExTests
 {
@@ -112,7 +117,7 @@ public class AssertExTests
         [Fact]
         public void WhenTaskReturningResult_WillItselfThrow()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.FromResult(1);
+            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
             Assert.Throws<AssertExException>(() => AssertEx.TaskThrows<BarException>(codeDelegate));
         }
 
@@ -129,14 +134,14 @@ public class AssertExTests
         [Fact]
         public void WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.FromResult(1);
+            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
             AssertEx.TaskDoesNotThrow(codeDelegate);
         }
 
         [Fact]
         public void ForGenericParameter_WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.FromResult(1);
+            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
             AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
         }
 
@@ -164,7 +169,7 @@ public class AssertExTests
         [Fact]
         public void UsingGenericType_WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.FromResult(1);
+            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
             AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
         }
     }

--- a/UnitTests/RecorderTests.cs
+++ b/UnitTests/RecorderTests.cs
@@ -3,6 +3,11 @@ using AssertExLib;
 using AssertExLib.Internal;
 using System;
 using Xunit;
+#if NET4
+using TaskEx = System.Threading.Tasks.TaskEx;
+#else
+using TaskEx = System.Threading.Tasks.Task;
+#endif
 
 public class RecorderTests
 {
@@ -52,7 +57,7 @@ public class RecorderTests
     [Fact]
     public void RecorderReturnsNullWhenTaskDoesNotThrow()
     {
-        var task = Task.FromResult(1);
+        var task = TaskEx.FromResult(1);
         TaskThrowsDelegate codeDelegate = () => task;
         var result = Recorder.Exception(codeDelegate);
         Assert.Null(result);

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="1.9.0.1566" />
+  <package id="xunit" version="1.9.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Updated xUnit to latest version
- Using Microsoft.CompilerServices.AsyncTargetingPack in NET4 test project to include missing behaviour
- Updated Portable Library config to do .NET4+ (was .NET4.5)

Next changes:
- cleanup - move code to src/ folder rather than at root of repo
- add Metro style test project
- ensure all tests are run from command line (but restricts dev environment to Windows 8 - thoughts?)
