### PR TITLE
RC Fixes

### DIFF
--- a/Build/Scripts.ps1
+++ b/Build/Scripts.ps1
@@ -53,7 +53,7 @@ function Output-Library {
     param([Parameter(Mandatory=$true)][string]$library)
 
     # add portable assembly to multiple paths
-    $folders = "net45", "sl50", "winrt45" # note: .NET 4 isn't supported here yet - trying to recall why...
+    $folders = "net40", "net45", "sl50", "winrt45"
     ForEach ($folder in $folders) {
 
         $newFolder = "$PackageDir\lib\$folder"


### PR DESCRIPTION
Just a few little things:
- Added net40 version to portable tools project and nuget package
- Logged issue #5 where tasks are not started and tests do not finish (will investigate best way to resolve this)

To run the tests yourself: `.\build-and-test.ps1` from the command line

To generate a new package: `.\create-package.ps1` from the command line.

To bump the version - set `$BaseVersion` in `.\Build\Scripts.ps1`
