### PR TITLE
Cleaned up task usage

### DIFF
--- a/Source/AssertEx.cs
+++ b/Source/AssertEx.cs
@@ -8,7 +8,6 @@ namespace AssertExLib
 {
     public delegate void ThrowsDelegate();
     public delegate object ThrowsDelegateWithReturn();
-    public delegate Task TaskThrowsDelegate();
 
     public static class AssertEx
     {
@@ -62,9 +61,9 @@ namespace AssertExLib
             return exception;
         }
 
-        public static T TaskThrows<T>(TaskThrowsDelegate testCode) where T : Exception
+        public static T TaskThrows<T>(Task task) where T : Exception
         {
-            var exception = Recorder.Exception(testCode);
+            var exception = Recorder.Exception(task);
 
             if (exception == null)
                 throw new AssertExException("AssertExtensions.Throws failed. No exception occurred.");
@@ -77,9 +76,9 @@ namespace AssertExLib
             return exceptionsMatching.First();
         }
 
-        public static void TaskDoesNotThrow(TaskThrowsDelegate testCode)
+        public static void TaskDoesNotThrow(Task task)
         {
-            var exception = Recorder.Exception(testCode);
+            var exception = Recorder.Exception(task);
 
             if (exception == null)
                 return;
@@ -88,9 +87,9 @@ namespace AssertExLib
             throw new AssertExException(String.Format("AssertExtensions.TaskDoesNotThrow failed. Incorrect exception {0} occurred.", exception.GetType().Name), exception);
         }
 
-        public static void TaskDoesNotThrow<T>(TaskThrowsDelegate testCode) where T : Exception
+        public static void TaskDoesNotThrow<T>(Task task) where T : Exception
         {
-            var exception = Recorder.Exception(testCode);
+            var exception = Recorder.Exception(task);
 
             if (exception == null)
                 return;

--- a/Source/Internal/Recorder.cs
+++ b/Source/Internal/Recorder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace AssertExLib.Internal
 {
@@ -44,13 +45,13 @@ namespace AssertExLib.Internal
         /// <summary>
         /// Records any exception which is thrown by the given code that returns a task.
         /// </summary>
-        /// <param name="code">The code which may thrown an exception.</param>
+        /// <param name="task">The task which may thrown an exception</param>
         /// <returns>Returns the exception that was thrown by the code; null, otherwise.</returns>
-        public static AggregateException Exception(TaskThrowsDelegate code)
+        public static AggregateException Exception(Task task)
         {
             try
             {
-                code().Wait();
+                task.Wait();
                 return null;
             }
             catch (AggregateException ex)

--- a/UnitTests/AssertExTests.cs
+++ b/UnitTests/AssertExTests.cs
@@ -96,36 +96,36 @@ public class AssertExTests
         [Fact]
         public void WhenTaskThrows_DetectsInnerException()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew(() => { throw new FooException(); });
-            AssertEx.TaskThrows<FooException>(codeDelegate);
+            var task = Task.Factory.StartNew(() => { throw new FooException(); });
+            AssertEx.TaskThrows<FooException>(task);
         }
 
         [Fact]
         public void WhenTaskReturningResultThrows_DetectsInnerException()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new FooException(); });
-            AssertEx.TaskThrows<FooException>(codeDelegate);
+            var task = Task.Factory.StartNew<int>(() => { throw new FooException(); });
+            AssertEx.TaskThrows<FooException>(task);
         }
 
         [Fact]
         public void WhenTaskReturningResultThrowsDifferent_WillItselfThrow()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new FooException(); });
-            Assert.Throws<AssertExException>(() => AssertEx.TaskThrows<BarException>(codeDelegate));
+            var task = Task.Factory.StartNew<int>(() => { throw new FooException(); });
+            Assert.Throws<AssertExException>(() => AssertEx.TaskThrows<BarException>(task));
         }
 
         [Fact]
         public void WhenTaskReturningResult_WillItselfThrow()
         {
-            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
-            Assert.Throws<AssertExException>(() => AssertEx.TaskThrows<BarException>(codeDelegate));
+            var task = TaskEx.FromResult(1);
+            Assert.Throws<AssertExException>(() => AssertEx.TaskThrows<BarException>(task));
         }
 
         [Fact]
         public void WhenTaskThrowsDifferentException_IsIgnored()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new BarException(); });
-            AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
+            var task = Task.Factory.StartNew<int>(() => { throw new BarException(); });
+            AssertEx.TaskDoesNotThrow<FooException>(task);
         }
     }
 
@@ -134,43 +134,43 @@ public class AssertExTests
         [Fact]
         public void WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
-            AssertEx.TaskDoesNotThrow(codeDelegate);
+            var task = TaskEx.FromResult(1);
+            AssertEx.TaskDoesNotThrow(task);
         }
 
         [Fact]
         public void ForGenericParameter_WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
-            AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
+            var task = TaskEx.FromResult(1);
+            AssertEx.TaskDoesNotThrow<FooException>(task);
         }
 
         [Fact]
         public void ForAnyException_WillItselfThrow()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new BarException(); });
-            Assert.Throws<AssertExException>(() => AssertEx.TaskDoesNotThrow(codeDelegate));
+            var task = Task.Factory.StartNew<int>(() => { throw new BarException(); });
+            Assert.Throws<AssertExException>(() => AssertEx.TaskDoesNotThrow(task));
         }
 
         [Fact]
         public void ForMatchingException_WillItselfThrow()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new FooException(); });
-            Assert.Throws<AssertExException>(() => AssertEx.TaskDoesNotThrow<FooException>(codeDelegate));
+            var task = Task.Factory.StartNew<int>(() => { throw new FooException(); });
+            Assert.Throws<AssertExException>(() => AssertEx.TaskDoesNotThrow<FooException>(task));
         }
 
         [Fact]
         public void WhereExceptionIsDifferent_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => Task.Factory.StartNew<int>(() => { throw new BarException(); });
-            AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
+            var task = Task.Factory.StartNew<int>(() => { throw new BarException(); });
+            AssertEx.TaskDoesNotThrow<FooException>(task);
         }
 
         [Fact]
         public void UsingGenericType_WhenTaskReturnsResult_IsSuccessful()
         {
-            TaskThrowsDelegate codeDelegate = () => TaskEx.FromResult(1);
-            AssertEx.TaskDoesNotThrow<FooException>(codeDelegate);
+            var task = TaskEx.FromResult(1);
+            AssertEx.TaskDoesNotThrow<FooException>(task);
         }
     }
 }

--- a/UnitTests/RecorderTests.cs
+++ b/UnitTests/RecorderTests.cs
@@ -40,7 +40,7 @@ public class RecorderTests
     [Fact]
     public void RecorderReturnsNullWhenThrowsDelegateWithReturnDoesNotThrow()
     {
-        ThrowsDelegateWithReturn codeDelegate = () => { return null; };
+        ThrowsDelegateWithReturn codeDelegate = () => null;
         var result = Recorder.Exception(codeDelegate);
         Assert.Null(result);
     }
@@ -49,8 +49,7 @@ public class RecorderTests
     public void RecorderCollectsExceptionThrownByTaskThrowsDelegate()
     {
         var task = Task.Factory.StartNew(() => { throw new FooException(); });
-        TaskThrowsDelegate codeDelegate = () => task;
-        var result = Recorder.Exception(codeDelegate);
+        var result = Recorder.Exception(task);
         Assert.IsAssignableFrom<AggregateException>(result);
     }
 
@@ -58,8 +57,7 @@ public class RecorderTests
     public void RecorderReturnsNullWhenTaskDoesNotThrow()
     {
         var task = TaskEx.FromResult(1);
-        TaskThrowsDelegate codeDelegate = () => task;
-        var result = Recorder.Exception(codeDelegate);
+        var result = Recorder.Exception(task);
         Assert.Null(result);
     }
 }


### PR DESCRIPTION
Removed the delegates involved with the async stuff. Sync code needs a delegate otherwise you can't pass that code around.

Task represents a async operation, so the delegate is not needed at all. One of the best thing about the async stuff is removing the lambda tax, we don't want to put it back in!
